### PR TITLE
Fix --n parameter and add parameter shorthands. Fixes #10

### DIFF
--- a/src/cloai/cli/parser.py
+++ b/src/cloai/cli/parser.py
@@ -189,6 +189,7 @@ def _add_image_generation_parser(
         type=str,
     )
     image_generation_parser.add_argument(
+        "-m",
         "--model",
         help=(
             "The model to use. Consult OpenAI's documentation for an up-to-date list"
@@ -198,6 +199,7 @@ def _add_image_generation_parser(
         default="dall-e-3",
     )
     image_generation_parser.add_argument(
+        "-s",
         "--size",
         help="The size of the generated image.",
         type=lambda x: x.lower(),
@@ -205,6 +207,7 @@ def _add_image_generation_parser(
         default="1024x1024",
     )
     image_generation_parser.add_argument(
+        "-q",
         "--quality",
         help="The quality of the generated image.",
         type=lambda x: x.lower(),
@@ -212,7 +215,8 @@ def _add_image_generation_parser(
         default="standard",
     )
     image_generation_parser.add_argument(
-        "--n",
+        "-n",
+        "--number",
         help="The number of images to generate.",
         type=_positive_int,
         default=1,
@@ -239,7 +243,7 @@ def _arg_validation(args: argparse.Namespace) -> argparse.Namespace:
     return args
 
 
-def _positive_int(value: int) -> int:
+def _positive_int(value: int | str) -> int:
     """Ensures the value is a positive integer.
 
     Args:
@@ -252,7 +256,7 @@ def _positive_int(value: int) -> int:
         exceptions.InvalidArgumentError: If the value is not an integer or not a
         positive integer.
     """
-    if int(value) != value:
+    if int(value) != float(value):
         msg = f"{value} is not an integer."
         raise exceptions.InvalidArgumentError(msg)
     if int(value) <= 0:

--- a/src/cloai/cli/parser.py
+++ b/src/cloai/cli/parser.py
@@ -75,7 +75,7 @@ async def run_command(args: argparse.Namespace) -> str | bytes | None:
             model=args.model,
             size=args.size,
             quality=args.quality,
-            n=args.n,
+            n=args.number,
         )
         return None
     if args.command == "tts":

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -275,6 +275,39 @@ async def test_parse_args_with_command_no_other_arguments(
     assert excinfo.value.code == expected_error_code
 
 
+@pytest.mark.asyncio()
+async def test_parse_args_from_cli_with_dalle_all_arguments(
+    mocker: pytest_mock.MockFixture,
+) -> None:
+    """Tests the parse_args function with the 'dalle' command and all arguments."""
+    command = mocker.patch("cloai.cli.commands.image_generation")
+    sys.argv = [
+        "cloai",
+        "dalle",
+        "test",
+        "test",
+        "--model",
+        "dall-e-3",
+        "--size",
+        "1024x1024",
+        "--quality",
+        "standard",
+        "--n",
+        "1",
+    ]
+
+    await parser.parse_args()
+
+    command.assert_called_once_with(
+        prompt="test",
+        output_base_name="test",
+        model="dall-e-3",
+        size="1024x1024",
+        quality="standard",
+        n=1,
+    )
+
+
 @pytest.mark.parametrize(
     "size",
     [

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -82,7 +82,7 @@ def test__add_image_generation_parser() -> None:
     assert arguments[5].help == "The quality of the generated image."
     assert arguments[5].default == "standard"
 
-    assert arguments[6].dest == "n"
+    assert arguments[6].dest == "number"
     assert arguments[6].help == "The number of images to generate."
     assert arguments[6].default == 1
 
@@ -203,7 +203,7 @@ async def test_run_command_with_dalle(mocker: pytest_mock.MockFixture) -> None:
         "model": "dall-e-3",
         "size": "1024x1024",
         "quality": "standard",
-        "n": 1,
+        "number": 1,
     }
     args = argparse.Namespace(**arg_dict)
     mock = mocker.patch("cloai.cli.commands.image_generation")
@@ -216,7 +216,7 @@ async def test_run_command_with_dalle(mocker: pytest_mock.MockFixture) -> None:
         model=arg_dict["model"],
         size=arg_dict["size"],
         quality=arg_dict["quality"],
-        n=arg_dict["n"],
+        n=arg_dict["number"],
     )
 
 
@@ -292,7 +292,7 @@ async def test_parse_args_from_cli_with_dalle_all_arguments(
         "1024x1024",
         "--quality",
         "standard",
-        "--n",
+        "-n",
         "1",
     ]
 


### PR DESCRIPTION
Fixes #10 

This pull request fixes the bug in DALL-E where it errors if the N parameter is provided. The issue is resolved by modifying the validation for the N parameter in the argparse module. Additionally, parameter shorthands are added for the model, size, quality, and number of images to generate. This allows for more convenient command line usage.